### PR TITLE
- parameterize get accounts to support multiple clients

### DIFF
--- a/src/Accounts.Api/Controllers/AccountsController.cs
+++ b/src/Accounts.Api/Controllers/AccountsController.cs
@@ -18,9 +18,9 @@ namespace Accounts.Api.Controllers
         }
 
         [HttpGet]
-        public async Task<GetAccountsOutput> Get() 
+        public async Task<GetAccountsOutput> Get(string clientId) 
         {
-            IEnumerable<Account> accounts = await _accountsRepo.GetAccounts();
+            IEnumerable<Account> accounts = await _accountsRepo.GetAccounts(clientId);
 
             return new GetAccountsOutput
             {

--- a/src/Accounts.Api/Controllers/TransactionsController.cs
+++ b/src/Accounts.Api/Controllers/TransactionsController.cs
@@ -17,9 +17,9 @@ namespace Accounts.Api.Controllers
         }
 
         [HttpGet("[action]")]
-        public async Task<IEnumerable<TransactionsPerCategoryAggregationModel>> Report(string accountResourceId)
+        public async Task<IEnumerable<TransactionsPerCategoryAggregationModel>> Report([FromQuery]GetTransactionsReportInput input)
         {
-            return await _getTransactionsReport.GetAccountTransactionsReport(accountResourceId);
+            return await _getTransactionsReport.GetAccountTransactionsReport(input);
         }
     }
 }

--- a/src/Accounts.Api/DataAccess/Accounts/IAccountsRepo.cs
+++ b/src/Accounts.Api/DataAccess/Accounts/IAccountsRepo.cs
@@ -6,6 +6,6 @@ namespace Accounts.Api.DataAccess.Accounts
 {
     public interface IAccountsRepo
     {
-        Task<IEnumerable<Account>> GetAccounts();
+        Task<IEnumerable<Account>> GetAccounts(string clientId);
     }
 }

--- a/src/Accounts.Api/DataAccess/Accounts/MockAccountsRepo.cs
+++ b/src/Accounts.Api/DataAccess/Accounts/MockAccountsRepo.cs
@@ -7,7 +7,8 @@ namespace Accounts.Api.DataAccess.Accounts
 {
     public class MockAccountsRepo : IAccountsRepo
     {
-        private static List<Account> Accounts = new List<Account> {
+        private static Dictionary<string, List<Account>> ClientAccounts = new Dictionary<string, List<Account>> {
+            { "9488caed-e06c-4c15-b168-4c43369fcd49", new List<Account> {
                 new Account {
                     ResourceId = "5aed4c3e-fd57-4c45-8f75-95787e52ebcf",
                     Product = "Product1",
@@ -23,18 +24,21 @@ namespace Accounts.Api.DataAccess.Accounts
                     Currency = "EUR"
                 },
                 new Account {
-                    ResourceId = "6e043036-c051-4516-b5bb-faac6cd89503",
-                    Product = "Product3",
-                    Iban = "RO69INGB0123456789",
-                    Name = "AccountName3",
-                    Currency = "EUR"
-                },
-                new Account {
                     ResourceId = "702c3f24-9930-4439-837c-a6615dbf0661",
                     Product = "Product4",
                     Iban = "RO69INGB0123456788",
                     Name = "AccountName4",
                     Currency = "RON"
+                },
+            }
+            },
+            { "aaf224d3-8be5-452a-a284-8558d2d819c0", new List<Account> {
+                new Account {
+                    ResourceId = "6e043036-c051-4516-b5bb-faac6cd89503",
+                    Product = "Product3",
+                    Iban = "RO69INGB0123456789",
+                    Name = "AccountName3",
+                    Currency = "EUR"
                 },
                 new Account {
                     ResourceId = "f9fb1cd5-8c9d-4227-ab19-4f44edcf3efd",
@@ -43,11 +47,13 @@ namespace Accounts.Api.DataAccess.Accounts
                     Name = "AccountName5",
                     Currency = "USD"
                 },
+            }
+            }
             };
 
-        public async Task<IEnumerable<Account>> GetAccounts()
+        public async Task<IEnumerable<Account>> GetAccounts(string clientId)
         {
-            return await Task.FromResult(Accounts);
+            return await Task.FromResult(ClientAccounts[clientId]);
         }
     }
 }

--- a/src/Accounts.Api/Features/Transactions/Report/GetTransactionsReport.cs
+++ b/src/Accounts.Api/Features/Transactions/Report/GetTransactionsReport.cs
@@ -25,16 +25,26 @@ namespace Accounts.Api.Features.Transactions.Report
             _dateTimeProxy = dateTimeProxy;
         }
 
-        public async Task<IEnumerable<TransactionsPerCategoryAggregationModel>> GetAccountTransactionsReport(string accountResourceId)
+        public async Task<IEnumerable<TransactionsPerCategoryAggregationModel>> GetAccountTransactionsReport(GetTransactionsReportInput input)
         {
             //TODO: Replace returning nulls with util constants
-            if (String.IsNullOrEmpty(accountResourceId))
+            if(input == null) 
             {
                 return null;
             }
 
-            IEnumerable<Account> accounts = await _accountsRepo.GetAccounts();
-            var account = accounts.SingleOrDefault(a => a.ResourceId == accountResourceId);
+            if (String.IsNullOrEmpty(input.ClientId))
+            {
+                return null;
+            }
+            
+            if (String.IsNullOrEmpty(input.AccountResourceId))
+            {
+                return null;
+            }
+
+            IEnumerable<Account> accounts = await _accountsRepo.GetAccounts(input.ClientId);
+            var account = accounts.SingleOrDefault(a => a.ResourceId == input.AccountResourceId);
             if (account == null)
             {
                 return null;

--- a/src/Accounts.Api/Features/Transactions/Report/Models/GetTransactionsReportInput.cs
+++ b/src/Accounts.Api/Features/Transactions/Report/Models/GetTransactionsReportInput.cs
@@ -1,0 +1,8 @@
+namespace Accounts.Api.Features.Transactions.Report.Models
+{
+    public class GetTransactionsReportInput
+    {
+        public string ClientId { get; set; }
+        public string AccountResourceId { get; set; }
+    }
+}


### PR DESCRIPTION
Parameterized get accounts in order to support multiple clients. Remove assumption that all accounts belong to a single client.